### PR TITLE
Feature: networking module

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ No modules.
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | `null` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_project"></a> [project](#input\_project) | The project name. | `string` | `"ghost"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | `null` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_environment"></a> [environment](#input\_environment) | The environment name for deployment. | `string` | `"production"` | no |
 | <a name="input_project"></a> [project](#input\_project) | The project name. | `string` | `"ghost"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | `null` | no |
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_enable_ha"></a> [enable\_ha](#input\_enable\_ha) | Choose whether to activate high availability or not. | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment name for deployment. | `string` | `"production"` | no |
 | <a name="input_project"></a> [project](#input\_project) | The project name. | `string` | `"ghost"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -13,17 +13,17 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | n/a |
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_networking"></a> [networking](#module\_networking) | ./networking |  |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [null_resource.hello_ghost](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 | Name | Version |
 |------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | n/a |
 
 ## Modules
@@ -23,6 +24,9 @@ No modules.
 | Name | Type |
 |------|------|
 | [null_resource.hello_ghost](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 

--- a/dependencies.tf
+++ b/dependencies.tf
@@ -1,0 +1,7 @@
+#####
+# General
+#####
+
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+data "aws_region" "current" {}

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,8 @@
+locals {
+  name = format("%s-%s-%s-%s",
+    var.project,
+    var.environment,
+    data.aws_caller_identity.current.account_id,
+    data.aws_region.current.name
+  )
+}

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
-resource "null_resource" "hello_ghost" {
-  provisioner "local-exec" {
-    command = "echo \"Hello Ghost!\""
-  }
+module "networking" {
+  source = "./networking"
+
+  prefix = local.name
 }

--- a/networking/README.md
+++ b/networking/README.md
@@ -26,7 +26,9 @@ No modules.
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | `null` | no |
 
 ## Outputs
 

--- a/networking/README.md
+++ b/networking/README.md
@@ -22,7 +22,10 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_subnet.this_private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_subnet.this_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
@@ -53,5 +56,9 @@ No modules.
 | <a name="output_vpc_ipv6_cidr_block"></a> [vpc\_ipv6\_cidr\_block](#output\_vpc\_ipv6\_cidr\_block) | The IPv6 CIDR block. |
 | <a name="output_vpc_main_route_table_id"></a> [vpc\_main\_route\_table\_id](#output\_vpc\_main\_route\_table\_id) | The ID of the main route table associated with this VPC. Note that you can change a VPC's main route table by using an aws\_main\_route\_table\_association. |
 | <a name="output_vpc_owner_id"></a> [vpc\_owner\_id](#output\_vpc\_owner\_id) | The ID of the AWS account that owns the VPC. |
+| <a name="output_vpc_private_subnet_arns"></a> [vpc\_private\_subnet\_arns](#output\_vpc\_private\_subnet\_arns) | The list if private subnet ARNs. |
+| <a name="output_vpc_private_subnet_ids"></a> [vpc\_private\_subnet\_ids](#output\_vpc\_private\_subnet\_ids) | The list if private subnet IDs. |
+| <a name="output_vpc_public_subnet_arns"></a> [vpc\_public\_subnet\_arns](#output\_vpc\_public\_subnet\_arns) | The list if public subnet ARNs. |
+| <a name="output_vpc_public_subnet_ids"></a> [vpc\_public\_subnet\_ids](#output\_vpc\_public\_subnet\_ids) | The list if public subnet IDs. |
 | <a name="output_vpc_tags_all"></a> [vpc\_tags\_all](#output\_vpc\_tags\_all) | A map of tags assigned to the resource, including those inherited from the provider default\_tags configuration block. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/networking/README.md
+++ b/networking/README.md
@@ -1,0 +1,34 @@
+# terraform-module-aws-networking (sub-module for Ghost CMS ecosystem)
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 0.14 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_null"></a> [null](#provider\_null) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [null_resource.hello_ghost](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/networking/README.md
+++ b/networking/README.md
@@ -13,7 +13,6 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | n/a |
 
 ## Modules
 
@@ -23,7 +22,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [null_resource.hello_ghost](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
@@ -34,8 +33,25 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | A prefix for each resource of the networking module. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | `null` | no |
+| <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | The VPC CIDR block for the Ghost CMS deployment. | `string` | `"192.168.194.0/23"` | no |
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_vpc_arn"></a> [vpc\_arn](#output\_vpc\_arn) | Amazon Resource Name (ARN) of VPC. |
+| <a name="output_vpc_cidr_block"></a> [vpc\_cidr\_block](#output\_vpc\_cidr\_block) | The CIDR block of the VPC. |
+| <a name="output_vpc_default_network_acl_id"></a> [vpc\_default\_network\_acl\_id](#output\_vpc\_default\_network\_acl\_id) | The ID of the network ACL created by default on VPC creation. |
+| <a name="output_vpc_default_route_table_id"></a> [vpc\_default\_route\_table\_id](#output\_vpc\_default\_route\_table\_id) | The ID of the route table created by default on VPC creation. |
+| <a name="output_vpc_default_security_group_id"></a> [vpc\_default\_security\_group\_id](#output\_vpc\_default\_security\_group\_id) | The ID of the security group created by default on VPC creation. |
+| <a name="output_vpc_enable_classiclink"></a> [vpc\_enable\_classiclink](#output\_vpc\_enable\_classiclink) | Whether or not the VPC has Classiclink enabled. |
+| <a name="output_vpc_enable_dns_hostnames"></a> [vpc\_enable\_dns\_hostnames](#output\_vpc\_enable\_dns\_hostnames) | Whether or not the VPC has DNS hostname support. |
+| <a name="output_vpc_enable_dns_support"></a> [vpc\_enable\_dns\_support](#output\_vpc\_enable\_dns\_support) | Whether or not the VPC has DNS support. |
+| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The ID of the VPC. |
+| <a name="output_vpc_instance_tenancy"></a> [vpc\_instance\_tenancy](#output\_vpc\_instance\_tenancy) | Tenancy of instances spin up within VPC. |
+| <a name="output_vpc_ipv6_association_id"></a> [vpc\_ipv6\_association\_id](#output\_vpc\_ipv6\_association\_id) | The association ID for the IPv6 CIDR block. |
+| <a name="output_vpc_ipv6_cidr_block"></a> [vpc\_ipv6\_cidr\_block](#output\_vpc\_ipv6\_cidr\_block) | The IPv6 CIDR block. |
+| <a name="output_vpc_main_route_table_id"></a> [vpc\_main\_route\_table\_id](#output\_vpc\_main\_route\_table\_id) | The ID of the main route table associated with this VPC. Note that you can change a VPC's main route table by using an aws\_main\_route\_table\_association. |
+| <a name="output_vpc_owner_id"></a> [vpc\_owner\_id](#output\_vpc\_owner\_id) | The ID of the AWS account that owns the VPC. |
+| <a name="output_vpc_tags_all"></a> [vpc\_tags\_all](#output\_vpc\_tags\_all) | A map of tags assigned to the resource, including those inherited from the provider default\_tags configuration block. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/networking/README.md
+++ b/networking/README.md
@@ -22,6 +22,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_internet_gateway.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
 | [aws_subnet.this_private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.this_public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
@@ -42,6 +43,8 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_igw_arn"></a> [igw\_arn](#output\_igw\_arn) | The ARN of the Internet Gateway. |
+| <a name="output_igw_id"></a> [igw\_id](#output\_igw\_id) | The ID of the Internet Gateway. |
 | <a name="output_vpc_arn"></a> [vpc\_arn](#output\_vpc\_arn) | Amazon Resource Name (ARN) of VPC. |
 | <a name="output_vpc_cidr_block"></a> [vpc\_cidr\_block](#output\_vpc\_cidr\_block) | The CIDR block of the VPC. |
 | <a name="output_vpc_default_network_acl_id"></a> [vpc\_default\_network\_acl\_id](#output\_vpc\_default\_network\_acl\_id) | The ID of the network ACL created by default on VPC creation. |

--- a/networking/README.md
+++ b/networking/README.md
@@ -31,9 +31,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_enable_ha"></a> [enable\_ha](#input\_enable\_ha) | Choose whether to activate high availability or not. | `bool` | `false` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | A prefix for each resource of the networking module. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | `null` | no |
-| <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | The VPC CIDR block for the Ghost CMS deployment. | `string` | `"192.168.194.0/23"` | no |
 
 ## Outputs
 

--- a/networking/README.md
+++ b/networking/README.md
@@ -32,6 +32,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | A prefix for each resource of the networking module. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | `null` | no |
 
 ## Outputs

--- a/networking/README.md
+++ b/networking/README.md
@@ -12,6 +12,7 @@
 
 | Name | Version |
 |------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | n/a |
 
 ## Modules
@@ -23,6 +24,9 @@ No modules.
 | Name | Type |
 |------|------|
 | [null_resource.hello_ghost](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 

--- a/networking/dependencies.tf
+++ b/networking/dependencies.tf
@@ -1,0 +1,7 @@
+#####
+# General
+#####
+
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+data "aws_region" "current" {}

--- a/networking/dependencies.tf
+++ b/networking/dependencies.tf
@@ -5,3 +5,7 @@
 data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 data "aws_region" "current" {}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}

--- a/networking/locals.tf
+++ b/networking/locals.tf
@@ -1,3 +1,6 @@
 locals {
-  vpc_name = "${var.prefix}-vpc"
+  vpc_name            = "${var.prefix}-vpc"
+  vpc_cidr            = "192.168.194.0/23"
+  subnet_public_name  = "${var.prefix}-subnet-public"
+  subnet_private_name = "${var.prefix}-subnet-private"
 }

--- a/networking/locals.tf
+++ b/networking/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  vpc_name = "${var.prefix}-vpc"
+}

--- a/networking/locals.tf
+++ b/networking/locals.tf
@@ -3,4 +3,5 @@ locals {
   vpc_cidr            = "192.168.194.0/23"
   subnet_public_name  = "${var.prefix}-subnet-public"
   subnet_private_name = "${var.prefix}-subnet-private"
+  igw_name            = "${var.prefix}-igw"
 }

--- a/networking/main.tf
+++ b/networking/main.tf
@@ -1,5 +1,11 @@
-resource "null_resource" "hello_ghost" {
-  provisioner "local-exec" {
-    command = "echo \"Hello Ghost!\""
-  }
+resource "aws_vpc" "this" {
+  cidr_block       = var.vpc_cidr
+  instance_tenancy = "default"
+
+  tags = merge(
+    {
+      Name = local.vpc_name
+    },
+    var.tags
+  )
 }

--- a/networking/main.tf
+++ b/networking/main.tf
@@ -1,0 +1,5 @@
+resource "null_resource" "hello_ghost" {
+  provisioner "local-exec" {
+    command = "echo \"Hello Ghost!\""
+  }
+}

--- a/networking/main.tf
+++ b/networking/main.tf
@@ -1,10 +1,49 @@
+#####
+# VPC
+#####
+
 resource "aws_vpc" "this" {
-  cidr_block       = var.vpc_cidr
+  cidr_block       = local.vpc_cidr
   instance_tenancy = "default"
 
   tags = merge(
     {
       Name = local.vpc_name
+    },
+    var.tags
+  )
+}
+
+
+#####
+# Subnets
+#####
+
+resource "aws_subnet" "this_public" {
+  count = var.enable_ha ? 2 : 1
+
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = cidrsubnet(local.vpc_cidr, 4, count.index)
+
+  tags = merge(
+    {
+      Name = "${local.subnet_public_name}-${count.index}"
+    },
+    var.tags
+  )
+}
+
+resource "aws_subnet" "this_private" {
+  count = var.enable_ha ? 2 : 1
+
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = cidrsubnet(local.vpc_cidr, 4, count.index + length(aws_subnet.this_public))
+
+  tags = merge(
+    {
+      Name = "${local.subnet_private_name}-${count.index}"
     },
     var.tags
   )

--- a/networking/main.tf
+++ b/networking/main.tf
@@ -48,3 +48,19 @@ resource "aws_subnet" "this_private" {
     var.tags
   )
 }
+
+
+#####
+# Internet Gateway
+#####
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(
+    {
+      Name = local.igw_name
+    },
+    var.tags
+  )
+}

--- a/networking/outputs.tf
+++ b/networking/outputs.tf
@@ -76,3 +76,28 @@ output "vpc_tags_all" {
   description = "A map of tags assigned to the resource, including those inherited from the provider default_tags configuration block."
   value       = aws_vpc.this.tags_all
 }
+
+
+#####
+# Subnets
+#####
+
+output "vpc_public_subnet_ids" {
+  description = "The list if public subnet IDs."
+  value       = aws_subnet.this_public.*.id
+}
+
+output "vpc_public_subnet_arns" {
+  description = "The list if public subnet ARNs."
+  value       = aws_subnet.this_public.*.arn
+}
+
+output "vpc_private_subnet_ids" {
+  description = "The list if private subnet IDs."
+  value       = aws_subnet.this_private.*.id
+}
+
+output "vpc_private_subnet_arns" {
+  description = "The list if private subnet ARNs."
+  value       = aws_subnet.this_private.*.arn
+}

--- a/networking/outputs.tf
+++ b/networking/outputs.tf
@@ -1,0 +1,78 @@
+#####
+# VPC
+#####
+
+output "vpc_arn" {
+  description = "Amazon Resource Name (ARN) of VPC."
+  value       = aws_vpc.this.arn
+}
+
+output "vpc_id" {
+  description = "The ID of the VPC."
+  value       = aws_vpc.this.id
+}
+
+output "vpc_cidr_block" {
+  description = "The CIDR block of the VPC."
+  value       = aws_vpc.this.cidr_block
+}
+
+output "vpc_instance_tenancy" {
+  description = "Tenancy of instances spin up within VPC."
+  value       = aws_vpc.this.instance_tenancy
+}
+
+output "vpc_enable_dns_support" {
+  description = "Whether or not the VPC has DNS support."
+  value       = aws_vpc.this.enable_dns_support
+}
+
+output "vpc_enable_dns_hostnames" {
+  description = "Whether or not the VPC has DNS hostname support."
+  value       = aws_vpc.this.enable_dns_hostnames
+}
+
+output "vpc_enable_classiclink" {
+  description = "Whether or not the VPC has Classiclink enabled."
+  value       = aws_vpc.this.enable_classiclink
+}
+
+output "vpc_main_route_table_id" {
+  description = "The ID of the main route table associated with this VPC. Note that you can change a VPC's main route table by using an aws_main_route_table_association."
+  value       = aws_vpc.this.main_route_table_id
+}
+
+output "vpc_default_network_acl_id" {
+  description = "The ID of the network ACL created by default on VPC creation."
+  value       = aws_vpc.this.default_network_acl_id
+}
+
+output "vpc_default_security_group_id" {
+  description = "The ID of the security group created by default on VPC creation."
+  value       = aws_vpc.this.default_security_group_id
+}
+
+output "vpc_default_route_table_id" {
+  description = "The ID of the route table created by default on VPC creation."
+  value       = aws_vpc.this.default_route_table_id
+}
+
+output "vpc_ipv6_association_id" {
+  description = "The association ID for the IPv6 CIDR block."
+  value       = aws_vpc.this.ipv6_association_id
+}
+
+output "vpc_ipv6_cidr_block" {
+  description = "The IPv6 CIDR block."
+  value       = aws_vpc.this.ipv6_cidr_block
+}
+
+output "vpc_owner_id" {
+  description = "The ID of the AWS account that owns the VPC."
+  value       = aws_vpc.this.owner_id
+}
+
+output "vpc_tags_all" {
+  description = "A map of tags assigned to the resource, including those inherited from the provider default_tags configuration block."
+  value       = aws_vpc.this.tags_all
+}

--- a/networking/outputs.tf
+++ b/networking/outputs.tf
@@ -101,3 +101,18 @@ output "vpc_private_subnet_arns" {
   description = "The list if private subnet ARNs."
   value       = aws_subnet.this_private.*.arn
 }
+
+
+#####
+# Internet Gateway
+#####
+
+output "igw_id" {
+  description = "The ID of the Internet Gateway."
+  value       = aws_internet_gateway.this.id
+}
+
+output "igw_arn" {
+  description = "The ARN of the Internet Gateway."
+  value       = aws_internet_gateway.this.arn
+}

--- a/networking/variables.tf
+++ b/networking/variables.tf
@@ -7,3 +7,13 @@ variable "tags" {
   type    = map(string)
   default = null
 }
+
+#####
+# VPC
+#####
+
+variable "vpc_cidr" {
+  default     = "192.168.194.0/23"
+  description = "The VPC CIDR block for the Ghost CMS deployment."
+  type        = string
+}

--- a/networking/variables.tf
+++ b/networking/variables.tf
@@ -4,8 +4,8 @@ variable "prefix" {
 }
 
 variable "tags" {
-  type    = map(string)
   default = null
+  type    = map(string)
 }
 
 #####

--- a/networking/variables.tf
+++ b/networking/variables.tf
@@ -1,3 +1,9 @@
+variable "enable_ha" {
+  description = "Choose whether to activate high availability or not."
+  default     = false
+  type        = bool
+}
+
 variable "prefix" {
   description = "A prefix for each resource of the networking module."
   type        = string
@@ -6,14 +12,4 @@ variable "prefix" {
 variable "tags" {
   default = null
   type    = map(string)
-}
-
-#####
-# VPC
-#####
-
-variable "vpc_cidr" {
-  default     = "192.168.194.0/23"
-  description = "The VPC CIDR block for the Ghost CMS deployment."
-  type        = string
 }

--- a/networking/variables.tf
+++ b/networking/variables.tf
@@ -1,0 +1,4 @@
+variable "tags" {
+  type    = map(string)
+  default = null
+}

--- a/networking/variables.tf
+++ b/networking/variables.tf
@@ -1,3 +1,8 @@
+variable "prefix" {
+  description = "A prefix for each resource of the networking module."
+  type        = string
+}
+
 variable "tags" {
   type    = map(string)
   default = null

--- a/networking/versions.tf
+++ b/networking/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 0.14"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,10 +1,16 @@
-variable "tags" {
-  type    = map(string)
-  default = null
+variable "environment" {
+  description = "The environment name for deployment."
+  default     = "production"
+  type        = string
 }
 
 variable "project" {
   description = "The project name."
   default     = "ghost"
   type        = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "enable_ha" {
+  description = "Choose whether to activate high availability or not."
+  default     = false
+  type        = bool
+}
+
 variable "environment" {
   description = "The environment name for deployment."
   default     = "production"

--- a/variables.tf
+++ b/variables.tf
@@ -2,3 +2,9 @@ variable "tags" {
   type    = map(string)
   default = null
 }
+
+variable "project" {
+  description = "The project name."
+  default     = "ghost"
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,4 @@
+variable "tags" {
+  type    = map(string)
+  default = null
+}


### PR DESCRIPTION
# Networking Module

- add a new sub-module dedicated to networking.
- this module comprises a VPC, public and private subnet(s), and an Internet Gateway for now.
- add locals to the module, in order to compute resource names based on the `prefix` input variable.
- add input variables: `prefix`, `tags` and `enable_ha` (to choose whether high availability should be enabled on the deployment).
- add data sources: `aws_caller_identity`, `aws_partition` and `aws_partition` and `aws_availability_zones` (only available ones).
