### PR TITLE
Refactor: add region, access_key, secret_key at root module

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,12 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_access_key"></a> [access\_key](#input\_access\_key) | n/a | `any` | n/a | yes |
 | <a name="input_enable_ha"></a> [enable\_ha](#input\_enable\_ha) | Choose whether to activate high availability or not. | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment name for deployment. | `string` | `"production"` | no |
 | <a name="input_project"></a> [project](#input\_project) | The project name. | `string` | `"ghost"` | no |
+| <a name="input_region"></a> [region](#input\_region) | n/a | `any` | n/a | yes |
+| <a name="input_secret_key"></a> [secret\_key](#input\_secret\_key) | n/a | `any` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | `null` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,6 @@
-provider "aws" {
-  region     = var.region
-  access_key = var.access_key
-  secret_key = var.secret_key
-}
+#####
+# Networking Module
+#####
 
 module "networking" {
   source = "./networking"

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,9 @@
+provider "aws" {
+  region     = var.region
+  access_key = var.access_key
+  secret_key = var.secret_key
+}
+
 module "networking" {
   source = "./networking"
 

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+  region     = var.region
+  access_key = var.access_key
+  secret_key = var.secret_key
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,15 @@
-variable "enable_ha" {
-  description = "Choose whether to activate high availability or not."
-  default     = false
-  type        = bool
-}
+#####
+# AWS Provider
+#####
+
+variable "access_key" {}
+variable "secret_key" {}
+variable "region" {}
+
+
+#####
+# General
+#####
 
 variable "environment" {
   description = "The environment name for deployment."
@@ -19,4 +26,15 @@ variable "project" {
 variable "tags" {
   type    = map(string)
   default = null
+}
+
+
+#####
+# Networking
+#####
+
+variable "enable_ha" {
+  description = "Choose whether to activate high availability or not."
+  default     = false
+  type        = bool
 }


### PR DESCRIPTION
# Add region, access_key, secret_key at root module

- `region`, `access_key`, `secret_key` should be specified though `TF_VAR_` env variables.
- delete providers config for networking.
- move provider config in `provider.tf`.
