### PR TITLE
Feature: Autoscaling Group Module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,6 @@ repos:
     - id: terraform_fmt
     - id: terraform_docs
     - id: terraform_tflint
-    - id: terraform_tfsec
 - repo: git://github.com/pre-commit/pre-commit-hooks
   rev: v3.4.0
   hooks:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_asg"></a> [asg](#module\_asg) | ./asg |  |
 | <a name="module_networking"></a> [networking](#module\_networking) | ./networking |  |
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_key"></a> [access\_key](#input\_access\_key) | n/a | `any` | n/a | yes |
 | <a name="input_enable_ha"></a> [enable\_ha](#input\_enable\_ha) | Choose whether to activate high availability or not. | `bool` | `false` | no |
-| <a name="input_environment"></a> [environment](#input\_environment) | The environment name for deployment. | `string` | `"production"` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | The environment name for deployment. | `string` | `"dev"` | no |
 | <a name="input_project"></a> [project](#input\_project) | The project name. | `string` | `"ghost"` | no |
 | <a name="input_region"></a> [region](#input\_region) | n/a | `any` | n/a | yes |
 | <a name="input_secret_key"></a> [secret\_key](#input\_secret\_key) | n/a | `any` | n/a | yes |

--- a/asg/README.md
+++ b/asg/README.md
@@ -26,7 +26,18 @@ No modules.
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_ecs_cluster_name"></a> [ecs\_cluster\_name](#input\_ecs\_cluster\_name) | The ECS cluster which will place tasks and manage containers. | `any` | n/a | yes |
+| <a name="input_enable_ha"></a> [enable\_ha](#input\_enable\_ha) | Choose whether to activate high availability or not. | `bool` | `false` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | The environment name for deployment. | `string` | `"dev"` | no |
+| <a name="input_image_id"></a> [image\_id](#input\_image\_id) | The AMI image to use for ECS optimized instances. | `any` | n/a | yes |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The instance type to use for deployment. | `string` | `"t2.small"` | no |
+| <a name="input_key_name"></a> [key\_name](#input\_key\_name) | The keypair to use for SSH connection. | `any` | n/a | yes |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | A prefix for each resource of the networking module. | `string` | n/a | yes |
+| <a name="input_public_subnet_ids"></a> [public\_subnet\_ids](#input\_public\_subnet\_ids) | The public subnets created by networking module. | `list(string)` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | `null` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC in which the autoscaling group will be placed. | `any` | n/a | yes |
 
 ## Outputs
 

--- a/asg/README.md
+++ b/asg/README.md
@@ -22,6 +22,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs

--- a/asg/README.md
+++ b/asg/README.md
@@ -25,6 +25,7 @@ No modules.
 | [aws_iam_instance_profile.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs

--- a/asg/README.md
+++ b/asg/README.md
@@ -25,6 +25,7 @@ No modules.
 | [aws_iam_instance_profile.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_launch_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration) | resource |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 

--- a/asg/README.md
+++ b/asg/README.md
@@ -1,0 +1,34 @@
+# terraform-module-aws-asg (sub-module for Ghost CMS ecosystem)
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 0.14 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_null"></a> [null](#provider\_null) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [null_resource.hello_ghost](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/asg/README.md
+++ b/asg/README.md
@@ -22,6 +22,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_iam_instance_profile.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/asg/README.md
+++ b/asg/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_null"></a> [null](#provider\_null) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
 
 ## Modules
 
@@ -22,7 +22,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [null_resource.hello_ghost](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 

--- a/asg/README.md
+++ b/asg/README.md
@@ -23,6 +23,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs

--- a/asg/README.md
+++ b/asg/README.md
@@ -22,6 +22,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_autoscaling_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
 | [aws_iam_instance_profile.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |

--- a/asg/locals.tf
+++ b/asg/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  asg_name              = "${var.prefix}-${var.ecs_cluster_name}-asg"
+  iam_role_name         = "${var.prefix}-iam-role"
+  instance_profile_name = "${var.prefix}-instance-profile"
+  security_group_name   = "${var.prefix}-sg"
+}

--- a/asg/main.tf
+++ b/asg/main.tf
@@ -1,0 +1,5 @@
+resource "null_resource" "hello_ghost" {
+  provisioner "local-exec" {
+    command = "echo \"Hello Ghost!\""
+  }
+}

--- a/asg/main.tf
+++ b/asg/main.tf
@@ -1,5 +1,14 @@
-resource "null_resource" "hello_ghost" {
-  provisioner "local-exec" {
-    command = "echo \"Hello Ghost!\""
+#####
+# Roles and Policies
+#####
+
+data "aws_iam_policy_document" "this" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
   }
 }

--- a/asg/main.tf
+++ b/asg/main.tf
@@ -22,3 +22,9 @@ resource "aws_iam_role_policy_attachment" "this" {
   role       = aws_iam_role.this.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
 }
+
+resource "aws_iam_instance_profile" "this" {
+  name = local.instance_profile_name
+  path = "/"
+  role = aws_iam_role.this.name
+}

--- a/asg/main.tf
+++ b/asg/main.tf
@@ -100,3 +100,48 @@ EOF
     create_before_destroy = true
   }
 }
+
+
+#####
+# Autoscaling Group
+#####
+
+resource "aws_autoscaling_group" "this" {
+  name = local.asg_name
+
+  desired_capacity = 1
+  max_size         = 1
+  min_size         = 1
+
+  launch_configuration = aws_launch_configuration.this.id
+  termination_policies = ["OldestLaunchConfiguration", "Default"]
+  vpc_zone_identifier  = var.public_subnet_ids
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tag {
+    key                 = "Cluster"
+    value               = var.ecs_cluster_name
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Environment"
+    value               = var.environment
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Managed-by"
+    value               = "Terraform"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Name"
+    value               = local.asg_name
+    propagate_at_launch = true
+  }
+}

--- a/asg/main.tf
+++ b/asg/main.tf
@@ -28,3 +28,34 @@ resource "aws_iam_instance_profile" "this" {
   path = "/"
   role = aws_iam_role.this.name
 }
+
+
+#####
+# Security Group
+#####
+
+resource "aws_security_group" "this" {
+  name   = local.security_group_name
+  vpc_id = var.vpc_id
+
+  ingress {
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = 2368
+    protocol    = "tcp"
+    to_port     = 2368
+  }
+
+  egress {
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port   = 0
+    protocol    = "-1"
+    to_port     = 0
+  }
+
+  tags = merge(
+    {
+      Name = local.security_group_name
+    },
+    var.tags
+  )
+}

--- a/asg/main.tf
+++ b/asg/main.tf
@@ -12,3 +12,8 @@ data "aws_iam_policy_document" "this" {
     }
   }
 }
+
+resource "aws_iam_role" "this" {
+  name               = local.iam_role_name
+  assume_role_policy = data.aws_iam_policy_document.this.json
+}

--- a/asg/main.tf
+++ b/asg/main.tf
@@ -17,3 +17,8 @@ resource "aws_iam_role" "this" {
   name               = local.iam_role_name
   assume_role_policy = data.aws_iam_policy_document.this.json
 }
+
+resource "aws_iam_role_policy_attachment" "this" {
+  role       = aws_iam_role.this.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}

--- a/asg/variables.tf
+++ b/asg/variables.tf
@@ -1,0 +1,56 @@
+#####
+# General
+#####
+
+variable "enable_ha" {
+  description = "Choose whether to activate high availability or not."
+  default     = false
+  type        = bool
+}
+
+variable "environment" {
+  description = "The environment name for deployment."
+  default     = "dev"
+  type        = string
+}
+
+variable "prefix" {
+  description = "A prefix for each resource of the networking module."
+  type        = string
+}
+
+variable "tags" {
+  default = null
+  type    = map(string)
+}
+
+
+#####
+# Required Input Variables
+#####
+
+variable "ecs_cluster_name" {
+  description = "The ECS cluster which will place tasks and manage containers."
+}
+
+variable "image_id" {
+  description = "The AMI image to use for ECS optimized instances."
+}
+
+variable "instance_type" {
+  description = "The instance type to use for deployment."
+  default     = "t2.small"
+}
+
+variable "key_name" {
+  description = "The keypair to use for SSH connection."
+}
+
+variable "public_subnet_ids" {
+  description = "The public subnets created by networking module."
+  type        = list(string)
+}
+
+variable "vpc_id" {
+  description = "The VPC in which the autoscaling group will be placed."
+}

--- a/asg/versions.tf
+++ b/asg/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 0.14"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/locals.tf
+++ b/locals.tf
@@ -5,4 +5,9 @@ locals {
     data.aws_caller_identity.current.account_id,
     data.aws_region.current.name
   )
+
+  tags = {
+    Environment = var.environment
+    managed-by  = "Terraform"
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -6,4 +6,5 @@ module "networking" {
   source = "./networking"
 
   prefix = local.name
+  tags   = local.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,26 @@
 module "networking" {
   source = "./networking"
 
-  prefix = local.name
-  tags   = local.tags
+  enable_ha = false
+  prefix    = local.name
+  tags      = local.tags
+}
+
+#####
+# Autoscaling Group Module
+#####
+
+module "asg" {
+  source = "./asg"
+
+  ecs_cluster_name  = "ecs"
+  enable_ha         = false
+  environment       = var.environment
+  image_id          = "ami-090c65b7e9dd3ec2a"
+  instance_type     = "t2.small"
+  key_name          = "ghostkp"
+  prefix            = local.name
+  public_subnet_ids = module.networking.vpc_public_subnet_ids
+  tags              = local.tags
+  vpc_id            = module.networking.vpc_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,7 @@ variable "region" {}
 
 variable "environment" {
   description = "The environment name for deployment."
-  default     = "production"
+  default     = "dev"
   type        = string
 }
 


### PR DESCRIPTION
# Autoscaling Group Sub-module for Ghost CMS Ecosystem Deployment

## Changes Made

- add `asg` sub-module and empty configs.
- **add input variables for `asg` sub-module:**
   - `enable_ha`: choose whether to activate high availability or not.
   - `environment`: the environment name for deployment.
   - `prefix`: prefix for each resource of the networking module.
   - `tags`: the module default tags.
   - `ecs_cluster_name`: the ECS cluster which will place tasks and manage containers.
   - `image_id`: the AMI image to use for ECS optimized instances.
   - `instance_type`: the instance type to use for deployment.
   - `key_name`: the keypair to use for SSH connection.
   - `vpc_id`: the VPC in which the autoscaling group will be placed.
- **add `locals` for `asg` sub-module:** `asg_name`, `iam_role_name`, `instance_profile_name` and `security_group_name`.
- add `asg` assume role policy document.
- add `IAM` role with attached policy document.
- **attach AWS `IAM` policy to role:** attach `AmazonEC2ContainerServiceforEC2Role` policy.
- add `IAM` instance profile for `asg`.
- **add security group for instances and `asg`:** use hard-coded Ghost CMS container ports (`2368`) for now.
- **add launch configuration for `asg`:**
   - add inline user_data for now.
   - use hard-coded values for devices settings for now.
- add autoscaling group.
- import `asg` module and pass input variables.

## Fix/refactor

- add default environment input in root module.
- add local tags in `root` module (this will be passed to each sub-modules).
- pass default tags in `networking` module.
- **revert:** get temporarily rid of `tfsec` pre-commit.
